### PR TITLE
Upgrade to a more up-to-date and accurate look

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can find this theme in the official [**Github Wiki**](https://github.com/ohm
 
 ## Format
  
- *`[desktop-name]`*:*`[current-dir]`* *`[user-name]`*$ 
+ *`[user-name]`*@*`[desktop-name]`* *`[current-dir]`* %
  
  ![Git](https://raw.githubusercontent.com/alejandromume/macos-zsh-theme-media/main/ezgif-1-d25fc7015a19.gif)
 

--- a/macos-theme.zsh-theme
+++ b/macos-theme.zsh-theme
@@ -1,4 +1,4 @@
-ll=$(last -1 -R $USER | awk 'NR==1 {print $4, $3, $5, $6, "on", $2}')
+ll=$(last -1 -R $USER | awk 'NR==1 {print $4, $3, $5, strftime("%T"), "on", $2}')
 echo "Last login: $ll"
 export PS1="Last login: [$ll]"'\n\h:\W\$ '
 

--- a/macos-theme.zsh-theme
+++ b/macos-theme.zsh-theme
@@ -11,7 +11,7 @@ git_prompt() {
    echo "$(git_prompt_info)"
 }
 
-PROMPT='%n@%m ~ %% '
+PROMPT='%n@%m %1~ %% '
 # RPROMPT='%{$FG[012]%} ► %{$fg[cyan]%}$(git_prompt_info)%{$FG[012]%} ◄ %{$reset_color%}';
 
 RPROMPT='$(git_prompt)'

--- a/macos-theme.zsh-theme
+++ b/macos-theme.zsh-theme
@@ -1,6 +1,6 @@
-ll=$(last -1 -R  $USER | head -1 | cut -c 23-)
-echo "Last Login: $ll"
-export PS1="Last Login: [$ll]"'\n\h:\W\$ '
+ll=$(last -1 -R $USER | awk 'NR==1 {print $4, $3, $5, $6, "on", $2}')
+echo "Last login: $ll"
+export PS1="Last login: [$ll]"'\n\h:\W\$ '
 
 ZSH_THEME_GIT_PROMPT_PREFIX="("
 ZSH_THEME_GIT_PROMPT_SUFFIX=")"
@@ -11,10 +11,7 @@ git_prompt() {
    echo "$(git_prompt_info)"
 }
 
-PROMPT='%{$fg[white]%}%m:%1~ %n$ '
+PROMPT='%n@%m ~ %% '
 # RPROMPT='%{$FG[012]%} ► %{$fg[cyan]%}$(git_prompt_info)%{$FG[012]%} ◄ %{$reset_color%}';
 
 RPROMPT='$(git_prompt)'
-
-
-


### PR DESCRIPTION
Title says it. Currently, this isn't how the terminal looks on macOS (at least not anymore). This pr fixes this by upgrading and improving this zsh theme to the current look of macOS terminal (See [here](https://help.apple.com/assets/63FFD63D71728623E706DB4F/63FFD63E71728623E706DB56/en_US/d13984f6116ed85e99ecd596f38ad831.png) from apple's site).

Here is your version:
![image](https://github.com/alejandromume/macos-zsh-theme/assets/59381835/1967ee06-be5d-4cd0-82c1-0a11536ca329)

Here's what I did:
![image](https://github.com/alejandromume/macos-zsh-theme/assets/59381835/d04e51ee-7a16-4eea-ae1c-a660ef8e1915)
